### PR TITLE
Merge MCP server into guestbook deployment

### DIFF
--- a/.github/workflows/cd-pipeline.yml
+++ b/.github/workflows/cd-pipeline.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches:
       - main
+    paths:
+      - "etc/guestbook/**"
+      - "docs/**"
+      - "cv.md"
+      - ".github/workflows/cd-pipeline.yml"
   workflow_dispatch:
 
 jobs:
@@ -11,6 +16,10 @@ jobs:
     runs-on: [self-hosted, macOS, ARM64]
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      OPENAI_MODEL: ${{ vars.OPENAI_MODEL != '' && vars.OPENAI_MODEL || 'gpt-4.1-mini' }}
+      OPENAI_API_BASE: ${{ vars.OPENAI_API_BASE != '' && vars.OPENAI_API_BASE || 'https://api.openai.com/v1' }}
+      GUESTBOOK_DATA_DIR: ${{ vars.GUESTBOOK_DATA_DIR != '' && vars.GUESTBOOK_DATA_DIR || './data' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -23,6 +32,18 @@ jobs:
 
       - name: Make runner.sh executable
         run: chmod +x etc/runner.sh
+
+      - name: Validate deploy env
+        shell: bash
+        run: |
+          set -eo pipefail
+          test -n "$OPENAI_API_KEY"
+
+      - name: Prepare guestbook data directory
+        shell: bash
+        run: |
+          set -eo pipefail
+          mkdir -p "$GUESTBOOK_DATA_DIR"
 #      - name: Setup Docker Buildx
 #        run: |
 #          docker buildx use default
@@ -34,6 +55,36 @@ jobs:
       - name: Run Docker Compose
         run: |
           ./etc/runner.sh etc/guestbook/docker-compose.yaml
+
+      - name: Verify local endpoints
+        shell: bash
+        run: |
+          set -eo pipefail
+          curl -fsS http://127.0.0.1:8000/health
+          python - <<'PY'
+          import sys
+          import urllib.error
+          import urllib.request
+
+          urls = [
+              "http://127.0.0.1:8000/mcp",
+              "http://127.0.0.1:8000/mcp/",
+          ]
+
+          for url in urls:
+              try:
+                  with urllib.request.urlopen(url, timeout=10) as response:
+                      print(f"{url} -> {response.status}")
+                      sys.exit(0)
+              except urllib.error.HTTPError as exc:
+                  if exc.code < 500:
+                      print(f"{url} -> HTTP {exc.code}")
+                      sys.exit(0)
+              except Exception as exc:
+                  print(f"{url} -> {exc}")
+
+          raise SystemExit("MCP endpoint did not respond successfully")
+          PY
 
       - name: server deploy monitoring end
         uses: ghkdqhrbals/build-monitoring@v1.0.3

--- a/etc/guestbook/Dockerfile
+++ b/etc/guestbook/Dockerfile
@@ -1,7 +1,8 @@
 FROM python:3.11-slim
 WORKDIR /app
-COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
-COPY app.py .
+COPY etc/guestbook/requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt
+COPY . /app
+WORKDIR /app/etc/guestbook
 EXPOSE 8000
 CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/etc/guestbook/__init__.py
+++ b/etc/guestbook/__init__.py
@@ -1,0 +1,1 @@
+# guestbook package marker

--- a/etc/guestbook/app.py
+++ b/etc/guestbook/app.py
@@ -1,15 +1,28 @@
 # app.py
+import hashlib
+import json
+import os
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Optional
+
+import requests
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
+from mcp.server.fastmcp import FastMCP
 from pydantic import BaseModel, Field
-from datetime import datetime, timezone, timedelta
-import hashlib
-from typing import Optional
-import os
-import requests
 from sqlalchemy import create_engine, Column, Integer, String, DateTime, ForeignKey
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker, relationship
+
+from blog_qa import (
+    answer_visitor_question,
+    collect_posts,
+    get_post_content as load_post_content,
+    list_categories_with_counts,
+    post_summary,
+    read_resume,
+)
 
 Base = declarative_base()
 
@@ -25,11 +38,26 @@ class Guestbook(Base):
     replies = relationship("Guestbook", backref="parent", remote_side=[id])
 
 database_url = os.getenv('DATABASE_URL', 'sqlite:///data/guestbook.db')
+if database_url.startswith("sqlite:///"):
+    sqlite_path = database_url.replace("sqlite:///", "", 1)
+    Path(sqlite_path).parent.mkdir(parents=True, exist_ok=True)
 engine = create_engine(database_url)
 Session = sessionmaker(bind=engine)
 Base.metadata.create_all(engine)
 
 app = FastAPI()
+
+mcp = FastMCP(
+    "ghkdqhrbals-blog",
+    instructions=(
+        "이 서버는 황보규민의 기술 블로그 최근 포스팅과 이력서 정보를 제공합니다. "
+        "get_recent_posts 로 최근 포스팅을 조회하고, "
+        "get_post_content 로 특정 포스팅 내용을, "
+        "get_resume 으로 이력서를 확인할 수 있습니다. "
+        "answer_visitor_question 으로 블로그 방문자 질문에 답변할 수도 있습니다."
+    ),
+    streamable_http_path="/",
+)
 
 # CORS 설정
 app.add_middleware(
@@ -44,6 +72,7 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+app.mount("/mcp", mcp.streamable_http_app())
 
 def hash_pw(pw: str) -> str:
     return hashlib.sha256(pw.encode()).hexdigest()
@@ -66,6 +95,52 @@ class CreateReq(BaseModel):
 class UpdateReq(BaseModel):
     password: str
     message: str = Field(..., max_length=500)
+
+
+@mcp.tool()
+def get_recent_posts(limit: int = 10, category: str = "") -> str:
+    limit = max(1, min(limit, 100))
+    posts = collect_posts()
+    if category:
+        posts = [p for p in posts if p.category.lower() == category.lower()]
+    return json.dumps([post_summary(p) for p in posts[:limit]], ensure_ascii=False, indent=2)
+
+
+@mcp.tool()
+def get_post_content(url_or_path: str) -> str:
+    return load_post_content(url_or_path)
+
+
+@mcp.tool()
+def get_resume() -> str:
+    content = read_resume()
+    return content or "이력서 파일을 찾을 수 없습니다."
+
+
+@mcp.tool()
+def list_categories() -> str:
+    return json.dumps(list_categories_with_counts(), ensure_ascii=False, indent=2)
+
+
+@mcp.tool()
+def answer_blog_visitor_question(question: str, page_url: str = "", page_title: str = "") -> str:
+    result = answer_visitor_question(question=question, page_url=page_url, page_title=page_title)
+    return json.dumps(result, ensure_ascii=False, indent=2)
+
+
+@mcp.resource("blog://recent")
+def resource_recent_posts() -> str:
+    return get_recent_posts()
+
+
+@mcp.resource("blog://resume")
+def resource_resume() -> str:
+    return get_resume()
+
+
+@mcp.resource("blog://categories")
+def resource_categories() -> str:
+    return list_categories()
 
 @app.get("/health")
 def health():

--- a/etc/guestbook/blog_qa.py
+++ b/etc/guestbook/blog_qa.py
@@ -1,0 +1,417 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import frontmatter
+
+BASE_DIR = Path(__file__).resolve().parents[2]
+DOCS_DIR = BASE_DIR / "docs"
+CV_PATH = BASE_DIR / "cv.md"
+SITE_BASE_URL = "https://ghkdqhrbals.github.io/portfolios"
+REMOTE_MCP_ALLOWED_TOOLS = [
+    "get_recent_posts",
+    "get_post_content",
+    "get_resume",
+    "list_categories",
+]
+
+
+@dataclass
+class PostRecord:
+    date: str
+    date_obj: datetime
+    title: str
+    parent: str
+    category: str
+    url: str
+    file_path: str
+    content: str
+
+
+def _normalize_text(value: str) -> str:
+    return re.sub(r"\s+", " ", (value or "").strip()).lower()
+
+
+def _tokenize(value: str) -> set[str]:
+    text = _normalize_text(value)
+    return {token for token in re.split(r"[^0-9a-zA-Z가-힣]+", text) if len(token) >= 2}
+
+
+def _load_markdown(path: Path):
+    return frontmatter.load(str(path))
+
+
+def collect_posts() -> list[PostRecord]:
+    posts: list[PostRecord] = []
+    if not DOCS_DIR.exists():
+        return posts
+
+    for md_file in sorted(DOCS_DIR.rglob("*.md")):
+        try:
+            post = _load_markdown(md_file)
+        except Exception:
+            continue
+
+        date_val = post.metadata.get("date")
+        title = post.metadata.get("title", "")
+        parent = post.metadata.get("parent", "")
+
+        if not date_val or not title:
+            continue
+
+        if isinstance(date_val, datetime):
+            date_obj = date_val
+            date_str = date_val.strftime("%Y-%m-%d")
+        else:
+            date_str = str(date_val)
+            try:
+                date_obj = datetime.strptime(date_str[:10], "%Y-%m-%d")
+            except ValueError:
+                continue
+
+        rel = md_file.relative_to(BASE_DIR)
+        url_path = "/" + str(rel).replace("\\", "/").replace(".md", "/")
+        url = SITE_BASE_URL.rstrip("/") + url_path
+        parts = rel.parts
+        category = parts[1] if len(parts) > 2 else ""
+
+        posts.append(
+            PostRecord(
+                date=date_str,
+                date_obj=date_obj,
+                title=title,
+                parent=parent,
+                category=category,
+                url=url,
+                file_path=str(md_file),
+                content=post.content,
+            )
+        )
+
+    posts.sort(key=lambda item: item.date_obj, reverse=True)
+    return posts
+
+
+def post_summary(post: PostRecord) -> dict[str, str]:
+    return {
+        "date": post.date,
+        "title": post.title,
+        "parent": post.parent,
+        "category": post.category,
+        "url": post.url,
+    }
+
+
+def read_resume() -> str:
+    if not CV_PATH.exists():
+        return ""
+    try:
+        post = _load_markdown(CV_PATH)
+        return post.content
+    except Exception:
+        return ""
+
+
+def get_post_content(url_or_path: str) -> str:
+    path_str = url_or_path
+    if path_str.startswith("http"):
+        prefix = SITE_BASE_URL.rstrip("/")
+        path_str = path_str[len(prefix):].lstrip("/")
+        path_str = path_str.rstrip("/") + ".md"
+
+    target = BASE_DIR / path_str
+    if not target.exists():
+        alt = BASE_DIR / path_str.replace(".md", "") / "index.md"
+        if alt.exists():
+            target = alt
+        else:
+            return f"오류: '{path_str}' 파일을 찾을 수 없습니다."
+
+    try:
+        post = _load_markdown(target)
+        meta_lines = [f"# {post.metadata.get('title', target.stem)}"]
+        if post.metadata.get("date"):
+            meta_lines.append(f"**날짜**: {post.metadata['date']}")
+        if post.metadata.get("parent"):
+            meta_lines.append(f"**카테고리**: {post.metadata['parent']}")
+        header = "\n".join(meta_lines)
+        return header + "\n\n---\n\n" + post.content
+    except Exception as exc:
+        return f"파일 읽기 오류: {exc}"
+
+
+def list_categories_with_counts() -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for post in collect_posts():
+        category = post.category or "기타"
+        counts[category] = counts.get(category, 0) + 1
+    return dict(sorted(counts.items(), key=lambda item: item[1], reverse=True))
+
+
+def _score_post(question_tokens: set[str], page_url: str, page_title: str, post: PostRecord) -> int:
+    score = 0
+    haystack_tokens = _tokenize(" ".join([post.title, post.parent, post.category, post.content[:2500]]))
+
+    score += len(question_tokens & haystack_tokens) * 4
+    score += len(question_tokens & _tokenize(post.title)) * 5
+
+    if page_title and _normalize_text(page_title) in _normalize_text(post.title):
+        score += 8
+    if page_url and post.url.rstrip("/") == page_url.rstrip("/"):
+        score += 20
+
+    return score
+
+
+def select_relevant_posts(question: str, page_url: str = "", page_title: str = "", limit: int = 4) -> list[PostRecord]:
+    tokens = _tokenize(question + " " + page_title)
+    ranked: list[tuple[int, PostRecord]] = []
+
+    for post in collect_posts():
+        score = _score_post(tokens, page_url, page_title, post)
+        if score > 0:
+            ranked.append((score, post))
+
+    ranked.sort(key=lambda item: (item[0], item[1].date_obj), reverse=True)
+    return [post for _, post in ranked[:limit]]
+
+
+def build_context(question: str, page_url: str = "", page_title: str = "") -> tuple[str, list[dict[str, str]]]:
+    sources: list[dict[str, str]] = []
+    chunks: list[str] = []
+
+    resume = read_resume()
+    if resume:
+        chunks.append("## Resume\n" + resume[:4000].strip())
+        sources.append({"type": "resume", "title": "CV", "url": SITE_BASE_URL + "/cv/"})
+
+    for post in select_relevant_posts(question, page_url=page_url, page_title=page_title):
+        excerpt = post.content.strip()[:3500]
+        chunks.append(
+            "\n".join(
+                [
+                    f"## Post: {post.title}",
+                    f"Date: {post.date}",
+                    f"Category: {post.category or post.parent or '기타'}",
+                    f"URL: {post.url}",
+                    excerpt,
+                ]
+            )
+        )
+        sources.append(
+            {
+                "type": "post",
+                "title": post.title,
+                "url": post.url,
+                "date": post.date,
+                "category": post.category,
+            }
+        )
+
+    return "\n\n".join(chunks).strip(), sources
+
+
+def _llm_config() -> tuple[str, str, str]:
+    api_key = os.getenv("OPENAI_API_KEY") or os.getenv("LLM_API_KEY") or ""
+    model = os.getenv("OPENAI_MODEL") or os.getenv("LLM_MODEL") or "gpt-4.1-mini"
+    api_base = (os.getenv("OPENAI_API_BASE") or os.getenv("LLM_API_BASE_URL") or "https://api.openai.com/v1").rstrip("/")
+    return api_key, model, api_base
+
+
+def _use_remote_mcp_with_responses() -> bool:
+    return bool((os.getenv("REMOTE_MCP_SERVER_URL") or "").strip())
+
+
+def _build_user_prompt(question: str, page_url: str = "", page_title: str = "") -> str:
+    return (
+        f"[방문자가 보고 있던 페이지]\n제목: {page_title or '-'}\nURL: {page_url or '-'}\n\n"
+        f"[질문]\n{question}"
+    )
+
+
+def _extract_output_text(body: dict[str, Any]) -> str:
+    output_text = body.get("output_text")
+    if isinstance(output_text, str) and output_text.strip():
+        return output_text.strip()
+
+    chunks: list[str] = []
+    for item in body.get("output", []) or []:
+        if item.get("type") != "message":
+            continue
+        for content in item.get("content", []) or []:
+            if content.get("type") in {"output_text", "text"} and content.get("text"):
+                chunks.append(str(content["text"]).strip())
+
+    return "\n".join(chunk for chunk in chunks if chunk).strip()
+
+
+def _sources_from_mcp_output(body: dict[str, Any]) -> list[dict[str, str]]:
+    sources: list[dict[str, str]] = []
+    seen: set[tuple[str, str]] = set()
+
+    for item in body.get("output", []) or []:
+        if item.get("type") != "mcp_call":
+            continue
+
+        name = str(item.get("name") or "")
+        args_raw = item.get("arguments") or "{}"
+        try:
+            args = json.loads(args_raw) if isinstance(args_raw, str) else dict(args_raw)
+        except Exception:
+            args = {}
+
+        source: dict[str, str] | None = None
+        if name == "get_resume":
+            source = {"type": "resume", "title": "CV", "url": SITE_BASE_URL + "/cv/"}
+        elif name == "get_post_content":
+            raw_value = str(args.get("url_or_path") or "").strip()
+            if raw_value:
+                source_url = raw_value
+                if not source_url.startswith("http"):
+                    source_url = SITE_BASE_URL.rstrip("/") + "/" + raw_value.strip("/").replace(".md", "/")
+                source = {"type": "post", "title": raw_value, "url": source_url}
+
+        if not source:
+            continue
+
+        dedupe_key = (source.get("type", ""), source.get("url", ""))
+        if dedupe_key not in seen:
+            seen.add(dedupe_key)
+            sources.append(source)
+
+    return sources
+
+
+def _call_chat_completion(system_prompt: str, user_prompt: str) -> str:
+    api_key, model, api_base = _llm_config()
+    if not api_key:
+        raise RuntimeError("OPENAI_API_KEY 또는 LLM_API_KEY 환경변수가 필요합니다.")
+
+    payload = {
+        "model": model,
+        "temperature": 0.2,
+        "messages": [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_prompt},
+        ],
+    }
+    req = urllib.request.Request(
+        url=f"{api_base}/chat/completions",
+        data=json.dumps(payload).encode("utf-8"),
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {api_key}",
+        },
+        method="POST",
+    )
+
+    try:
+        with urllib.request.urlopen(req, timeout=45) as response:
+            body = json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"AI provider error: HTTP {exc.code} - {detail}") from exc
+    except urllib.error.URLError as exc:
+        raise RuntimeError(f"AI provider connection error: {exc}") from exc
+
+    choices = body.get("choices") or []
+    if not choices:
+        raise RuntimeError("AI provider returned no choices.")
+
+    message = choices[0].get("message") or {}
+    content = message.get("content")
+    if isinstance(content, str):
+        return content.strip()
+    if isinstance(content, list):
+        parts = [part.get("text", "") for part in content if isinstance(part, dict)]
+        return "\n".join(part for part in parts if part).strip()
+    raise RuntimeError("AI provider returned an unsupported response format.")
+
+
+def _call_responses_with_remote_mcp(system_prompt: str, user_prompt: str) -> dict[str, Any]:
+    api_key, model, api_base = _llm_config()
+    if not api_key:
+        raise RuntimeError("OPENAI_API_KEY 또는 LLM_API_KEY 환경변수가 필요합니다.")
+
+    remote_mcp_server_url = (os.getenv("REMOTE_MCP_SERVER_URL") or "").strip()
+    if not remote_mcp_server_url:
+        raise RuntimeError("REMOTE_MCP_SERVER_URL 환경변수가 필요합니다.")
+
+    payload = {
+        "model": model,
+        "instructions": system_prompt,
+        "input": user_prompt,
+        "tools": [
+            {
+                "type": "mcp",
+                "server_label": "blog_mcp",
+                "server_url": remote_mcp_server_url,
+                "allowed_tools": REMOTE_MCP_ALLOWED_TOOLS,
+                "require_approval": "never",
+            }
+        ],
+    }
+
+    req = urllib.request.Request(
+        url=f"{api_base}/responses",
+        data=json.dumps(payload).encode("utf-8"),
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {api_key}",
+        },
+        method="POST",
+    )
+
+    try:
+        with urllib.request.urlopen(req, timeout=60) as response:
+            body = json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"Responses API error: HTTP {exc.code} - {detail}") from exc
+    except urllib.error.URLError as exc:
+        raise RuntimeError(f"Responses API connection error: {exc}") from exc
+
+    answer = _extract_output_text(body)
+    if not answer:
+        raise RuntimeError("Responses API returned no output text.")
+
+    return {"answer": answer, "sources": _sources_from_mcp_output(body)}
+
+
+def answer_visitor_question(question: str, page_url: str = "", page_title: str = "") -> dict[str, Any]:
+    clean_question = (question or "").strip()
+    if not clean_question:
+        raise ValueError("question is required")
+    if len(clean_question) > 1500:
+        raise ValueError("question is too long")
+
+    system_prompt = (
+        "너는 황보규민의 블로그 방문자 질문을 대신 답변하는 AI다. "
+        "답변은 한국어로 작성한다. "
+        "가능하면 먼저 연결된 MCP 도구를 사용해서 필요한 정보만 찾아본 뒤 답한다. "
+        "제공된 MCP 도구와 그 결과 안에서만 답하고, 추측이 필요한 경우에는 추측이라고 밝힌다. "
+        "정보가 없으면 모른다고 답한다. "
+        "답변 끝에는 짧게 핵심만 정리하고, 필요한 경우 참고한 글 제목이나 이력서를 언급한다."
+    )
+    user_prompt = _build_user_prompt(clean_question, page_url=page_url, page_title=page_title)
+
+    if _use_remote_mcp_with_responses():
+        result = _call_responses_with_remote_mcp(system_prompt, user_prompt)
+        result["mode"] = "responses_remote_mcp"
+        return result
+
+    context, sources = build_context(clean_question, page_url=page_url, page_title=page_title)
+    if not context:
+        raise RuntimeError("블로그 컨텍스트를 찾지 못했습니다.")
+
+    fallback_user_prompt = user_prompt + f"\n\n[참고 컨텍스트]\n{context}"
+    answer = _call_chat_completion(system_prompt, fallback_user_prompt)
+    return {"answer": answer, "sources": sources, "mode": "chat_completions_context_fallback"}

--- a/etc/guestbook/docker-compose.yaml
+++ b/etc/guestbook/docker-compose.yaml
@@ -1,10 +1,15 @@
 services:
   guestbook:
-    build: .
+    build:
+      context: ../..
+      dockerfile: etc/guestbook/Dockerfile
     ports:
       - "8000:8000"
     volumes:
-      - /Users/gyuminhwangbo/data:/data
+      - ${GUESTBOOK_DATA_DIR:-./data}:/data
     environment:
       - DATABASE_URL=sqlite:////data/guestbook.db
       - SLACK_WEBHOOK_URL=${SLACK_WEBHOOK_URL}
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - OPENAI_MODEL=${OPENAI_MODEL:-gpt-4.1-mini}
+      - OPENAI_API_BASE=${OPENAI_API_BASE:-https://api.openai.com/v1}

--- a/etc/guestbook/requirements.txt
+++ b/etc/guestbook/requirements.txt
@@ -3,3 +3,5 @@ uvicorn
 requests
 jsonrpcserver
 sqlalchemy
+mcp
+python-frontmatter


### PR DESCRIPTION
## Summary
- merge the blog/CV MCP server into the existing guestbook FastAPI app and expose it at `/mcp`
- update the guestbook container and compose setup to include the MCP dependencies and OpenAI environment variables
- update the existing CD workflow to validate deploy env, prepare the data directory, deploy the merged app, and verify `/health` plus `/mcp`

## Validation
- `python3 -m py_compile etc/guestbook/app.py etc/guestbook/blog_qa.py`
- `docker compose -f etc/guestbook/docker-compose.yaml config`
- `docker compose -f etc/guestbook/docker-compose.yaml build guestbook`