### PR TITLE
Update guestbook MCP streaming and PR tests

### DIFF
--- a/.github/workflows/guestbook-tests.yml
+++ b/.github/workflows/guestbook-tests.yml
@@ -12,6 +12,11 @@ on:
       - "etc/guestbook/**"
       - ".github/workflows/guestbook-tests.yml"
 
+permissions:
+  contents: read
+  checks: write
+  pull-requests: write
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -37,4 +42,13 @@ jobs:
         env:
           DATABASE_URL: sqlite:////tmp/guestbook-test.db
           PUBLIC_MCP_SERVER_URL: https://lowfidev.cloud/mcp/
-        run: pytest -q
+        run: pytest -q --junitxml=test-results/pytest.xml
+
+      - name: Publish test results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        if: always()
+        with:
+          files: etc/guestbook/test-results/pytest.xml
+          check_name: Guestbook pytest
+          comment_mode: always
+          job_summary: true

--- a/.github/workflows/guestbook-tests.yml
+++ b/.github/workflows/guestbook-tests.yml
@@ -1,0 +1,40 @@
+name: Guestbook Tests
+
+on:
+  pull_request:
+    paths:
+      - "etc/guestbook/**"
+      - ".github/workflows/guestbook-tests.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "etc/guestbook/**"
+      - ".github/workflows/guestbook-tests.yml"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: etc/guestbook
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+          cache-dependency-path: etc/guestbook/requirements-test.txt
+
+      - name: Install dependencies
+        run: python -m pip install -r requirements-test.txt
+
+      - name: Run tests
+        env:
+          DATABASE_URL: sqlite:////tmp/guestbook-test.db
+          PUBLIC_MCP_SERVER_URL: https://lowfidev.cloud/mcp/
+        run: pytest -q

--- a/MCP_SERVER_FEATURE_SPEC.md
+++ b/MCP_SERVER_FEATURE_SPEC.md
@@ -15,6 +15,22 @@ The server provides read-oriented access to the public blog at:
 
 It does not depend on a local checkout of the `portfolios` project for content resolution anymore. Recent posts, CV content, and individual article content are fetched from the live site.
 
+## Wiki Release Notes
+
+### 2026-04-29 배포 반영
+
+- `POST /ask/stream` SSE endpoint 추가
+- OpenAI Responses API 스트리밍 relay 지원
+- MCP 도구 호출 이벤트(`tool_call`)를 프론트로 실시간 전달 (`tool`, `arguments`)
+- 최종 `done` 이벤트에서 `result.answer`, `result.sources`, `result.tool_calls`, `result.mode`를 함께 전달
+
+운영 반영 시 확인사항:
+
+1. `PUBLIC_MCP_SERVER_URL` 또는 `REMOTE_MCP_SERVER_URL` 이 설정되어 있어야 함
+2. 프론트에서 `Accept: text/event-stream` 처리 및 SSE reconnect 정책 필요
+3. 이벤트 타입별 UI 처리 필요 (`answer_delta`, `tool_call`, `done`, `error`)
+4. 스트리밍은 remote MCP + Responses API 모드에서만 지원됨
+
 ## Goals
 
 - Expose blog and CV information through MCP tools and resources
@@ -63,16 +79,47 @@ Request body:
 
 SSE events:
 
-- `answer_delta`: 모델 답변 토큰/문자열 증분
-- `tool_call`: MCP tool 호출 정보 (`tool`, `arguments`)
-- `done`: 최종 집계 결과 (`answer`, `sources`, `tool_calls`, `mode`)
-- `error`: 처리 중 오류
+- `answer_delta`: 모델 답변 토큰/문자열 증분 (`delta`)
+- `tool_call`: MCP tool 호출 정보 (`tool_call.tool`, `tool_call.arguments`)
+- `done`: 최종 집계 결과 (`result.answer`, `result.sources`, `result.tool_calls`, `result.mode`)
+- `error`: 처리 중 오류 (`error`)
+
+Each SSE message uses the standard `event` and `data` fields. The `data` field is JSON.
+
+Answer delta example:
+
+```text
+event: answer_delta
+data: {"event":"answer_delta","call_id":"...","delta":"Redis Stream의 pending은 ..."}
+```
+
+Tool call example:
+
+```text
+event: tool_call
+data: {"event":"tool_call","call_id":"...","tool_call":{"tool":"search_posts","arguments":{"query":"Redis Stream pending"}}}
+```
+
+Done example:
+
+```text
+event: done
+data: {"event":"done","call_id":"...","result":{"answer":"...","sources":[{"title":"...","url":"..."}],"tool_calls":[{"tool":"search_posts","arguments":{"query":"Redis Stream pending"}}],"mode":"responses_remote_mcp_stream"}}
+```
+
+Error example:
+
+```text
+event: error
+data: {"error":"PUBLIC_MCP_SERVER_URL 또는 REMOTE_MCP_SERVER_URL 환경변수가 필요합니다."}
+```
 
 Notes:
 
 - `/ask/stream` 는 OpenAI Responses API의 streaming 응답을 프론트로 relay 한다.
-- `tool_call` 이벤트는 모델이 실제 MCP tool 호출을 추가하는 시점에 전달된다.
+- `tool_call` 이벤트는 MCP tool 호출 인자가 확정되거나 호출 item이 완료된 시점에 전달된다.
 - 스트리밍 모드는 remote MCP URL이 설정된 경우(`PUBLIC_MCP_SERVER_URL` 또는 `REMOTE_MCP_SERVER_URL`)에 동작한다.
+- 요청의 `question`은 필수이며 최대 1500자까지 허용한다.
 
 ### MCP Transport Endpoint
 
@@ -116,6 +163,9 @@ Allowed hosts:
 Allowed origins:
 
 - `https://lowfidev.cloud`
+- `https://api.openai.com`
+- `https://chatgpt.com`
+- `https://platform.openai.com`
 - `http://localhost:8000`
 - `http://127.0.0.1:8000`
 

--- a/etc/guestbook/.dockerignore
+++ b/etc/guestbook/.dockerignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+data/

--- a/etc/guestbook/Dockerfile
+++ b/etc/guestbook/Dockerfile
@@ -1,8 +1,7 @@
 FROM python:3.11-slim
 WORKDIR /app
-COPY etc/guestbook/requirements.txt /tmp/requirements.txt
+COPY requirements.txt /tmp/requirements.txt
 RUN pip install --no-cache-dir -r /tmp/requirements.txt
 COPY . /app
-WORKDIR /app/etc/guestbook
 EXPOSE 8000
 CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000", "--proxy-headers", "--forwarded-allow-ips=*"]

--- a/etc/guestbook/app.py
+++ b/etc/guestbook/app.py
@@ -3,13 +3,16 @@ import contextlib
 import hashlib
 import json
 import os
+import threading
 from datetime import datetime, timedelta, timezone
+from collections import defaultdict, deque
 from pathlib import Path
 from typing import Optional
 
 import requests
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import StreamingResponse
 from mcp.server.fastmcp import FastMCP
 from mcp.server.transport_security import TransportSecuritySettings
 from pydantic import BaseModel, Field
@@ -81,6 +84,9 @@ mcp = FastMCP(
             "MCP_ALLOWED_ORIGINS",
             [
                 "https://lowfidev.cloud",
+                "https://api.openai.com",
+                "https://chatgpt.com",
+                "https://platform.openai.com",
                 "http://localhost:8000",
                 "http://127.0.0.1:8000",
             ],
@@ -112,6 +118,11 @@ app.add_middleware(
 )
 app.mount("/mcp", mcp.streamable_http_app())
 
+ASK_RATE_LIMIT_PER_MINUTE = max(1, int(os.getenv("ASK_RATE_LIMIT_PER_MINUTE", "10")))
+ASK_RATE_LIMIT_WINDOW_SECONDS = 60
+_ask_rate_limit_lock = threading.Lock()
+_ask_rate_limit_hits: dict[str, deque[float]] = defaultdict(deque)
+
 def hash_pw(pw: str) -> str:
     return hashlib.sha256(pw.encode()).hexdigest()
 
@@ -139,6 +150,31 @@ class AskReq(BaseModel):
     question: str = Field(..., min_length=1, max_length=1500)
     page_url: str = ""
     page_title: str = ""
+
+
+def _client_ip(request: Request) -> str:
+    forwarded_for = (request.headers.get("x-forwarded-for") or "").strip()
+    if forwarded_for:
+        return forwarded_for.split(",")[0].strip()
+    real_ip = (request.headers.get("x-real-ip") or "").strip()
+    if real_ip:
+        return real_ip
+    return request.client.host if request.client else "unknown"
+
+
+def _enforce_ask_rate_limit(request: Request) -> None:
+    client_ip = _client_ip(request)
+    now = datetime.now().timestamp()
+
+    with _ask_rate_limit_lock:
+        hits = _ask_rate_limit_hits[client_ip]
+        while hits and now - hits[0] >= ASK_RATE_LIMIT_WINDOW_SECONDS:
+            hits.popleft()
+
+        if len(hits) >= ASK_RATE_LIMIT_PER_MINUTE:
+            raise HTTPException(429, f"Too many requests. Limit is {ASK_RATE_LIMIT_PER_MINUTE} per minute.")
+
+        hits.append(now)
 
 
 def _public_mcp_server_url(request: Request) -> str:
@@ -220,6 +256,7 @@ def health():
 
 @app.post("/ask")
 def ask(req: AskReq, request: Request):
+    _enforce_ask_rate_limit(request)
     result = answer_visitor_question(
         question=req.question,
         page_url=req.page_url,
@@ -228,10 +265,37 @@ def ask(req: AskReq, request: Request):
     )
     return result
 
+
+@app.post("/ask/stream")
+def ask_stream(req: AskReq, request: Request):
+    def event_stream():
+        try:
             for event in stream_visitor_question(
+                question=req.question,
+                page_url=req.page_url,
+                page_title=req.page_title,
+                remote_mcp_server_url=_public_mcp_server_url(request),
             ):
                 event_name = str(event.get("event") or "message")
                 yield f"event: {event_name}\ndata: {json.dumps(event, ensure_ascii=False)}\n\n"
+        except Exception as exc:
+            yield f"event: error\ndata: {json.dumps({'error': str(exc)}, ensure_ascii=False)}\n\n"
+
+    return StreamingResponse(event_stream(), media_type="text/event-stream")
+
+@app.post("/guestbook")
+def create(req: CreateReq):
+    session = Session()
+    try:
+        if req.parent_id is not None:
+            parent = session.query(Guestbook).filter(Guestbook.id == req.parent_id).first()
+            if not parent:
+                raise HTTPException(404, "parent not found")
+            if parent.page != req.page:
+                raise HTTPException(400, "parent page mismatch")
+        entry = Guestbook(
+            name=req.name,
+            pw_hash=hash_pw(req.password),
             message=req.message,
             page=req.page,
             created_at=datetime.utcnow(),

--- a/etc/guestbook/blog_qa.py
+++ b/etc/guestbook/blog_qa.py
@@ -472,6 +472,30 @@ def _tool_calls_from_mcp_output(body: dict[str, Any]) -> list[dict[str, Any]]:
     return calls
 
 
+def _format_tool_call_line(tool_call: dict[str, Any]) -> str:
+    tool_name = str(tool_call.get("tool") or "").strip()
+    if not tool_name:
+        return ""
+
+    arguments = tool_call.get("arguments")
+    if isinstance(arguments, dict) and arguments:
+        args = ", ".join(f"{key}={value!r}" for key, value in arguments.items())
+        return f"tools... {tool_name}({args})\n"
+    return f"tools... {tool_name}()\n"
+
+
+def _prepend_tool_call_lines(answer: str, tool_calls: list[dict[str, Any]]) -> str:
+    lines = [_format_tool_call_line(tool_call).strip() for tool_call in tool_calls]
+    lines = [line for line in lines if line]
+    if not lines:
+        return answer
+
+    prefix = "\n".join(lines)
+    if answer.startswith(prefix):
+        return answer
+    return f"{prefix}\n{answer}".strip()
+
+
 def _parse_tool_arguments(args_raw: Any) -> dict[str, Any]:
     try:
         return json.loads(args_raw) if isinstance(args_raw, str) else dict(args_raw or {})
@@ -619,6 +643,7 @@ def _call_responses_with_remote_mcp(
 
     sources = _sources_from_mcp_output(body)
     tool_calls = _tool_calls_from_mcp_output(body)
+    answer = _prepend_tool_call_lines(answer, tool_calls)
     normalized_sources = _normalize_sources(sources)
     return {
         "answer": answer,
@@ -678,7 +703,13 @@ def _stream_responses_with_remote_mcp(
         seen_tools.add(dedupe_key)
         tool_call = {"tool": tool_name, "arguments": arguments}
         tool_calls.append(tool_call)
-        return {"event": "tool_call", "call_id": call_id, "tool_call": tool_call}
+        line = _format_tool_call_line(tool_call)
+        if line:
+            answer_chunks.append(line)
+        return [
+            {"event": "tool_call", "call_id": call_id, "tool_call": tool_call},
+            {"event": "answer_delta", "call_id": call_id, "delta": line},
+        ]
 
     seen_event_types: list[str] = []
     ignored_lines: list[str] = []
@@ -720,9 +751,7 @@ def _stream_responses_with_remote_mcp(
             key = _mcp_call_key(event)
             cached = mcp_call_items.setdefault(key, {"tool": "", "arguments": {}})
             cached["arguments"] = _parse_tool_arguments(event.get("arguments") or "{}")
-            emitted = emit_tool_call(str(cached.get("tool") or ""), cached["arguments"])
-            if emitted:
-                emitted_events.append(emitted)
+            emitted_events.extend(emit_tool_call(str(cached.get("tool") or ""), cached["arguments"]) or [])
         elif event_type == "response.output_item.done":
             item = event.get("item") or {}
             if item.get("type") == "message" and not answer_chunks:
@@ -736,9 +765,7 @@ def _stream_responses_with_remote_mcp(
                 cached["tool"] = str(item.get("name") or cached.get("tool") or "")
                 if "arguments" in item:
                     cached["arguments"] = _parse_tool_arguments(item.get("arguments") or "{}")
-                emitted = emit_tool_call(str(cached.get("tool") or ""), cached.get("arguments") or {})
-                if emitted:
-                    emitted_events.append(emitted)
+                emitted_events.extend(emit_tool_call(str(cached.get("tool") or ""), cached.get("arguments") or {}) or [])
         elif event_type == "response.completed":
             response_body = event.get("response") or {}
             if isinstance(response_body, dict):
@@ -806,17 +833,17 @@ def _stream_responses_with_remote_mcp(
         raise RuntimeError(f"Responses API connection error: {exc}") from exc
 
     answer = "".join(answer_chunks).strip()
-    if not answer:
-        answer = _extract_output_text(final_response)
-        if answer:
-            yield {"event": "answer_delta", "call_id": call_id, "delta": answer}
+    final_answer = _extract_output_text(final_response)
+    if final_answer and final_answer not in answer:
+        separator = "\n" if answer else ""
+        answer = f"{answer}{separator}{final_answer}".strip()
+        yield {"event": "answer_delta", "call_id": call_id, "delta": f"{separator}{final_answer}"}
 
     sources: list[dict[str, str]] = []
     sources = _normalize_sources(_sources_from_mcp_output(final_response))
     if not tool_calls:
         for tool_call in _tool_calls_from_mcp_output(final_response):
-            emitted = emit_tool_call(str(tool_call.get("tool") or ""), tool_call.get("arguments") or {})
-            if emitted:
+            for emitted in emit_tool_call(str(tool_call.get("tool") or ""), tool_call.get("arguments") or {}) or []:
                 yield emitted
 
     if not answer and not tool_calls:

--- a/etc/guestbook/blog_qa.py
+++ b/etc/guestbook/blog_qa.py
@@ -472,6 +472,24 @@ def _tool_calls_from_mcp_output(body: dict[str, Any]) -> list[dict[str, Any]]:
     return calls
 
 
+def _parse_tool_arguments(args_raw: Any) -> dict[str, Any]:
+    try:
+        return json.loads(args_raw) if isinstance(args_raw, str) else dict(args_raw or {})
+    except Exception:
+        return {"_raw": str(args_raw)}
+
+
+def _mcp_call_key(event: dict[str, Any], item: dict[str, Any] | None = None) -> str:
+    if item:
+        item_id = str(item.get("id") or "")
+        if item_id:
+            return item_id
+    item_id = str(event.get("item_id") or "")
+    if item_id:
+        return item_id
+    return f"output:{event.get('output_index', '')}"
+
+
 def _normalize_sources(sources: list[dict[str, str]]) -> list[dict[str, str]]:
     normalized: list[dict[str, str]] = []
     seen: set[tuple[str, str]] = set()
@@ -650,48 +668,137 @@ def _stream_responses_with_remote_mcp(
     answer_chunks: list[str] = []
     tool_calls: list[dict[str, Any]] = []
     seen_tools: set[str] = set()
+    mcp_call_items: dict[str, dict[str, Any]] = {}
     final_response: dict[str, Any] | None = None
+
+    def emit_tool_call(tool_name: str, arguments: dict[str, Any]):
+        dedupe_key = json.dumps({"tool": tool_name, "arguments": arguments}, ensure_ascii=False, sort_keys=True)
+        if not tool_name or dedupe_key in seen_tools:
+            return None
+        seen_tools.add(dedupe_key)
+        tool_call = {"tool": tool_name, "arguments": arguments}
+        tool_calls.append(tool_call)
+        return {"event": "tool_call", "call_id": call_id, "tool_call": tool_call}
+
+    seen_event_types: list[str] = []
+    ignored_lines: list[str] = []
+
+    def handle_stream_event(event: dict[str, Any]) -> list[dict[str, Any]]:
+        event_type = str(event.get("type") or "")
+        if event_type:
+            seen_event_types.append(event_type)
+
+        emitted_events: list[dict[str, Any]] = []
+
+        if event_type == "error":
+            error = event.get("error") or event
+            raise RuntimeError(f"Responses API stream error: {json.dumps(error, ensure_ascii=False)}")
+        if event_type in {"response.failed", "response.incomplete"}:
+            response_body = event.get("response") or {}
+            error = response_body.get("error") or response_body.get("incomplete_details") or response_body
+            raise RuntimeError(f"Responses API {event_type}: {json.dumps(error, ensure_ascii=False)}")
+
+        if event_type == "response.output_text.delta":
+            delta = str(event.get("delta") or "")
+            if delta:
+                answer_chunks.append(delta)
+                emitted_events.append({"event": "answer_delta", "call_id": call_id, "delta": delta})
+        elif event_type == "response.output_text.done":
+            text = str(event.get("text") or "")
+            if text and not answer_chunks:
+                answer_chunks.append(text)
+                emitted_events.append({"event": "answer_delta", "call_id": call_id, "delta": text})
+        elif event_type == "response.output_item.added":
+            item = event.get("item") or {}
+            if item.get("type") == "mcp_call":
+                key = _mcp_call_key(event, item)
+                mcp_call_items[key] = {
+                    "tool": str(item.get("name") or ""),
+                    "arguments": _parse_tool_arguments(item.get("arguments") or "{}"),
+                }
+        elif event_type == "response.mcp_call_arguments.done":
+            key = _mcp_call_key(event)
+            cached = mcp_call_items.setdefault(key, {"tool": "", "arguments": {}})
+            cached["arguments"] = _parse_tool_arguments(event.get("arguments") or "{}")
+            emitted = emit_tool_call(str(cached.get("tool") or ""), cached["arguments"])
+            if emitted:
+                emitted_events.append(emitted)
+        elif event_type == "response.output_item.done":
+            item = event.get("item") or {}
+            if item.get("type") == "message" and not answer_chunks:
+                text = _extract_output_text({"output": [item]})
+                if text:
+                    answer_chunks.append(text)
+                    emitted_events.append({"event": "answer_delta", "call_id": call_id, "delta": text})
+            elif item.get("type") == "mcp_call":
+                key = _mcp_call_key(event, item)
+                cached = mcp_call_items.setdefault(key, {"tool": "", "arguments": {}})
+                cached["tool"] = str(item.get("name") or cached.get("tool") or "")
+                if "arguments" in item:
+                    cached["arguments"] = _parse_tool_arguments(item.get("arguments") or "{}")
+                emitted = emit_tool_call(str(cached.get("tool") or ""), cached.get("arguments") or {})
+                if emitted:
+                    emitted_events.append(emitted)
+        elif event_type == "response.completed":
+            response_body = event.get("response") or {}
+            if isinstance(response_body, dict):
+                final_response.update(response_body)
+
+        return emitted_events
+
+    final_response = {}
 
     try:
         with urllib.request.urlopen(req, timeout=120) as response:
+            data_lines: list[str] = []
             for raw_line in response:
-                line = raw_line.decode("utf-8", errors="replace").strip()
-                if not line.startswith("data: "):
+                line = raw_line.decode("utf-8", errors="replace").rstrip("\r\n")
+                if line == "":
+                    if not data_lines:
+                        continue
+                    data = "\n".join(data_lines)
+                    data_lines = []
+                    if data == "[DONE]":
+                        break
+                    try:
+                        event = json.loads(data)
+                    except json.JSONDecodeError:
+                        ignored_lines.append(data)
+                        continue
+                    for emitted in handle_stream_event(event):
+                        yield emitted
                     continue
-                data = line[6:]
-                if data == "[DONE]":
-                    break
 
+                if line.startswith("data:"):
+                    data_lines.append(line[5:].lstrip())
+                    continue
+                if line.startswith(("event:", "id:", "retry:", ":")):
+                    continue
+
+                ignored_lines.append(line)
+
+            if data_lines:
+                data = "\n".join(data_lines)
+                if data != "[DONE]":
+                    try:
+                        event = json.loads(data)
+                    except json.JSONDecodeError:
+                        ignored_lines.append(data)
+                    else:
+                        for emitted in handle_stream_event(event):
+                            yield emitted
+
+            if not seen_event_types and ignored_lines:
+                body_text = "\n".join(ignored_lines).strip()
                 try:
-                    event = json.loads(data)
+                    body = json.loads(body_text)
                 except json.JSONDecodeError:
-                    continue
-
-                event_type = str(event.get("type") or "")
-
-                if event_type == "response.output_text.delta":
-                    delta = str(event.get("delta") or "")
-                    if delta:
-                        answer_chunks.append(delta)
-                        yield {"event": "answer_delta", "call_id": call_id, "delta": delta}
-                elif event_type == "response.output_item.added":
-                    item = event.get("item") or {}
-                    if item.get("type") == "mcp_call":
-                        tool_name = str(item.get("name") or "")
-                        args_raw = item.get("arguments") or "{}"
-                        try:
-                            arguments = json.loads(args_raw) if isinstance(args_raw, str) else dict(args_raw)
-                        except Exception:
-                            arguments = {"_raw": str(args_raw)}
-
-                        dedupe_key = json.dumps({"tool": tool_name, "arguments": arguments}, ensure_ascii=False, sort_keys=True)
-                        if dedupe_key not in seen_tools:
-                            seen_tools.add(dedupe_key)
-                            tool_call = {"tool": tool_name, "arguments": arguments}
-                            tool_calls.append(tool_call)
-                            yield {"event": "tool_call", "call_id": call_id, "tool_call": tool_call}
-                elif event_type == "response.completed":
-                    final_response = (event.get("response") or {})
+                    preview = body_text[:500]
+                    raise RuntimeError(f"Responses API returned non-SSE data: {preview}")
+                if isinstance(body, dict) and body.get("error"):
+                    raise RuntimeError(f"Responses API error: {json.dumps(body['error'], ensure_ascii=False)}")
+                if isinstance(body, dict):
+                    final_response.update(body)
     except urllib.error.HTTPError as exc:
         detail = exc.read().decode("utf-8", errors="replace")
         raise RuntimeError(f"Responses API error: HTTP {exc.code} - {detail}") from exc
@@ -699,12 +806,27 @@ def _stream_responses_with_remote_mcp(
         raise RuntimeError(f"Responses API connection error: {exc}") from exc
 
     answer = "".join(answer_chunks).strip()
-    if not answer and isinstance(final_response, dict):
+    if not answer:
         answer = _extract_output_text(final_response)
+        if answer:
+            yield {"event": "answer_delta", "call_id": call_id, "delta": answer}
 
     sources: list[dict[str, str]] = []
-    if isinstance(final_response, dict):
-        sources = _normalize_sources(_sources_from_mcp_output(final_response))
+    sources = _normalize_sources(_sources_from_mcp_output(final_response))
+    if not tool_calls:
+        for tool_call in _tool_calls_from_mcp_output(final_response):
+            emitted = emit_tool_call(str(tool_call.get("tool") or ""), tool_call.get("arguments") or {})
+            if emitted:
+                yield emitted
+
+    if not answer and not tool_calls:
+        status = str(final_response.get("status") or "")
+        error = final_response.get("error") or final_response.get("incomplete_details") or ""
+        event_summary = ", ".join(dict.fromkeys(seen_event_types)) or "none"
+        raise RuntimeError(
+            "Responses stream produced no answer or tool calls. "
+            f"status={status or '-'}, events={event_summary}, error={json.dumps(error, ensure_ascii=False)}"
+        )
 
     yield {
         "event": "done",

--- a/etc/guestbook/blog_qa.py
+++ b/etc/guestbook/blog_qa.py
@@ -718,6 +718,7 @@ def _stream_responses_with_remote_mcp(
     }
 
 
+
 def answer_visitor_question(
     question: str,
     page_url: str = "",

--- a/etc/guestbook/blog_qa.py
+++ b/etc/guestbook/blog_qa.py
@@ -861,6 +861,7 @@ def answer_visitor_question(
         "제공된 MCP 도구와 그 결과 안에서만 답하고, 추측이 필요한 경우에는 추측이라고 밝힌다. "
         "정보가 없으면 모른다고 답한다. "
         "참고 링크를 포함할 때는 반드시 Markdown 링크 형식 [제목](URL) 만 사용하고, 생 URL은 쓰지 않는다. "
+        "특히 https://ghkdqhrbals.github.io/portfolios/docs 로 시작하는 URL은 반드시 [글 제목](URL) Markdown 링크 형식으로만 작성한다. "
         "링크가 필요하면 [링크](URL) 같은 일반 라벨 대신 글 제목 자체를 링크로 만든다. "
         "URL 끝의 불필요한 trailing slash 는 제거된 형태를 사용한다. "
         "답변 말미에 관련 포스팅이나 이력서를 언급할 때는 가능하면 Markdown 링크로 직접 연결한다. "
@@ -910,7 +911,11 @@ def stream_visitor_question(
         "가능하면 먼저 연결된 MCP 도구를 사용해서 필요한 정보만 찾아본 뒤 답한다. "
         "특정 주제, 키워드, 기술명을 물으면 search_posts 를 우선 사용해 관련 글을 찾는다. "
         "제공된 MCP 도구와 그 결과 안에서만 답하고, 추측이 필요한 경우에는 추측이라고 밝힌다. "
-        "정보가 없으면 모른다고 답한다."
+        "정보가 없으면 모른다고 답한다. "
+        "참고 링크를 포함할 때는 반드시 Markdown 링크 형식 [제목](URL) 만 사용하고, 생 URL은 쓰지 않는다. "
+        "특히 https://ghkdqhrbals.github.io/portfolios/docs 로 시작하는 URL은 반드시 [글 제목](URL) Markdown 링크 형식으로만 작성한다. "
+        "링크가 필요하면 [링크](URL) 같은 일반 라벨 대신 글 제목 자체를 링크로 만든다. "
+        "URL 끝의 불필요한 trailing slash 는 제거된 형태를 사용한다."
     )
     user_prompt = _build_user_prompt(clean_question, page_url=page_url, page_title=page_title)
     yield from _stream_responses_with_remote_mcp(

--- a/etc/guestbook/docker-compose.yaml
+++ b/etc/guestbook/docker-compose.yaml
@@ -1,8 +1,8 @@
 services:
   guestbook:
     build:
-      context: ../..
-      dockerfile: etc/guestbook/Dockerfile
+      context: .
+      dockerfile: Dockerfile
     ports:
       - "8000:8000"
     volumes:

--- a/etc/guestbook/requirements-test.txt
+++ b/etc/guestbook/requirements-test.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+pytest
+httpx

--- a/etc/guestbook/tests/test_app.py
+++ b/etc/guestbook/tests/test_app.py
@@ -1,6 +1,10 @@
 from collections import deque
+from pathlib import Path
+import sys
 
 from fastapi.testclient import TestClient
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 import app as guestbook_app
 

--- a/etc/guestbook/tests/test_app.py
+++ b/etc/guestbook/tests/test_app.py
@@ -1,0 +1,111 @@
+from collections import deque
+
+from fastapi.testclient import TestClient
+
+import app as guestbook_app
+
+
+def _ask_payload(question: str = "Redis Stream pending이 뭐야?") -> dict[str, str]:
+    return {
+        "question": question,
+        "page_url": "https://ghkdqhrbals.github.io/portfolios/docs/redis-stream",
+        "page_title": "Redis Stream",
+    }
+
+
+def _stub_answer(**kwargs):
+    return {
+        "answer": "stubbed answer",
+        "sources": [],
+        "tool_calls": [],
+        "mode": "test",
+        "received_question": kwargs["question"],
+    }
+
+
+def setup_function():
+    guestbook_app._ask_rate_limit_hits.clear()
+
+
+def test_health_endpoint():
+    client = TestClient(guestbook_app.app)
+
+    response = client.get("/health")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+def test_ask_rate_limit_allows_limit_then_rejects_same_ip(monkeypatch):
+    monkeypatch.setattr(guestbook_app, "ASK_RATE_LIMIT_PER_MINUTE", 2)
+    monkeypatch.setattr(guestbook_app, "answer_visitor_question", _stub_answer)
+    monkeypatch.setattr(guestbook_app, "_public_mcp_server_url", lambda request: "https://lowfidev.cloud/mcp/")
+    client = TestClient(guestbook_app.app)
+    headers = {"X-Forwarded-For": "203.0.113.10"}
+
+    first = client.post("/ask", json=_ask_payload("first"), headers=headers)
+    second = client.post("/ask", json=_ask_payload("second"), headers=headers)
+    third = client.post("/ask", json=_ask_payload("third"), headers=headers)
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert third.status_code == 429
+    assert third.json()["detail"] == "Too many requests. Limit is 2 per minute."
+    assert len(guestbook_app._ask_rate_limit_hits["203.0.113.10"]) == 2
+
+
+def test_ask_rate_limit_is_isolated_by_client_ip(monkeypatch):
+    monkeypatch.setattr(guestbook_app, "ASK_RATE_LIMIT_PER_MINUTE", 1)
+    monkeypatch.setattr(guestbook_app, "answer_visitor_question", _stub_answer)
+    monkeypatch.setattr(guestbook_app, "_public_mcp_server_url", lambda request: "https://lowfidev.cloud/mcp/")
+    client = TestClient(guestbook_app.app)
+
+    first_ip_first = client.post("/ask", json=_ask_payload(), headers={"X-Forwarded-For": "203.0.113.11"})
+    first_ip_second = client.post("/ask", json=_ask_payload(), headers={"X-Forwarded-For": "203.0.113.11"})
+    second_ip_first = client.post("/ask", json=_ask_payload(), headers={"X-Forwarded-For": "203.0.113.12"})
+
+    assert first_ip_first.status_code == 200
+    assert first_ip_second.status_code == 429
+    assert second_ip_first.status_code == 200
+
+
+def test_ask_rate_limit_prefers_first_forwarded_for_ip(monkeypatch):
+    monkeypatch.setattr(guestbook_app, "ASK_RATE_LIMIT_PER_MINUTE", 1)
+    monkeypatch.setattr(guestbook_app, "answer_visitor_question", _stub_answer)
+    monkeypatch.setattr(guestbook_app, "_public_mcp_server_url", lambda request: "https://lowfidev.cloud/mcp/")
+    client = TestClient(guestbook_app.app)
+    headers = {"X-Forwarded-For": "203.0.113.13, 10.0.0.1"}
+
+    first = client.post("/ask", json=_ask_payload(), headers=headers)
+    second = client.post("/ask", json=_ask_payload(), headers=headers)
+
+    assert first.status_code == 200
+    assert second.status_code == 429
+    assert "203.0.113.13" in guestbook_app._ask_rate_limit_hits
+    assert "10.0.0.1" not in guestbook_app._ask_rate_limit_hits
+
+
+def test_ask_rate_limit_expires_old_hits(monkeypatch):
+    monkeypatch.setattr(guestbook_app, "ASK_RATE_LIMIT_PER_MINUTE", 1)
+    monkeypatch.setattr(guestbook_app, "ASK_RATE_LIMIT_WINDOW_SECONDS", 60)
+    monkeypatch.setattr(guestbook_app, "answer_visitor_question", _stub_answer)
+    monkeypatch.setattr(guestbook_app, "_public_mcp_server_url", lambda request: "https://lowfidev.cloud/mcp/")
+    guestbook_app._ask_rate_limit_hits["203.0.113.14"] = deque([1000.0])
+
+    class FixedDateTime:
+        @staticmethod
+        def now():
+            class FixedNow:
+                @staticmethod
+                def timestamp():
+                    return 1060.0
+
+            return FixedNow()
+
+    monkeypatch.setattr(guestbook_app, "datetime", FixedDateTime)
+    client = TestClient(guestbook_app.app)
+
+    response = client.post("/ask", json=_ask_payload(), headers={"X-Forwarded-For": "203.0.113.14"})
+
+    assert response.status_code == 200
+    assert list(guestbook_app._ask_rate_limit_hits["203.0.113.14"]) == [1060.0]


### PR DESCRIPTION
## Summary

This PR carries the guestbook MCP work on `feature/mcp` instead of direct `main` changes. It fixes remote MCP streaming integration, narrows the guestbook Docker build context, asks the LLM to emit portfolio docs URLs as Markdown links, shows called MCP tools in streamed answers, and adds pytest coverage for guestbook endpoints.

## Testing

- `/tmp/guestbook-test-venv/bin/python -m pytest -q --junitxml=test-results/pytest.xml`
- Result: 5 passed

## CI

The guestbook test workflow runs on pull requests touching `etc/guestbook/**` and publishes JUnit results as a PR comment.